### PR TITLE
Fix #2 - Support entities

### DIFF
--- a/src/main/java/io/vertx/docgen/BaseProcessor.java
+++ b/src/main/java/io/vertx/docgen/BaseProcessor.java
@@ -1,13 +1,6 @@
 package io.vertx.docgen;
 
-import com.sun.source.doctree.DocCommentTree;
-import com.sun.source.doctree.DocTree;
-import com.sun.source.doctree.DocTreeVisitor;
-import com.sun.source.doctree.EndElementTree;
-import com.sun.source.doctree.ErroneousTree;
-import com.sun.source.doctree.LinkTree;
-import com.sun.source.doctree.StartElementTree;
-import com.sun.source.doctree.TextTree;
+import com.sun.source.doctree.*;
 import com.sun.source.util.DocTreeScanner;
 import com.sun.source.util.DocTrees;
 import com.sun.source.util.TreePath;
@@ -282,6 +275,12 @@ public abstract class BaseProcessor extends AbstractProcessor {
         }
         writer.append(body, prev, body.length());
         return super.visitText(node, v);
+      }
+
+      @Override
+      public Void visitEntity(EntityTree node, Void aVoid) {
+        writer.append(EntityUtils.unescapeEntity(node.getName().toString()));
+        return super.visitEntity(node, aVoid);
       }
 
       @Override

--- a/src/main/java/io/vertx/docgen/EntityUtils.java
+++ b/src/main/java/io/vertx/docgen/EntityUtils.java
@@ -1,0 +1,61 @@
+package io.vertx.docgen;
+
+/**
+ * An utility class to handle entities.
+ */
+public final class EntityUtils {
+
+  private EntityUtils() {
+    // Avoid direct instantiation.
+  }
+
+  /**
+   * Computes the character represented by the given entity. The entity can be given as {@code #xx} or as
+   * {@code uXXXX}. Other form are wrapped into `&` and `;`. This wrapping is allowed as Asciidoctor
+   * supports HTML entities, so we don't have to maintain a translation table.
+   *
+   * @param input the entity
+   * @return the represented character
+   */
+  public static String unescapeEntity(String input) {
+    if (input == null || input.trim().length() == 0) {
+      return "";
+    }
+    if (input.startsWith("#")) {
+      // The reference number can be either in hex or decimal: &#x020AC; or &#8364;.
+      String withoutPrefix = input.substring(1);
+      if (! withoutPrefix.isEmpty()  && withoutPrefix.startsWith("x")) {
+        withoutPrefix = withoutPrefix.substring(1);
+        return parseAsHexa(input, withoutPrefix);
+      } else {
+        return parseAsDecimal(input, withoutPrefix);
+      }
+    }
+    if (input.startsWith("u")) {
+      String withoutPrefix = input.substring(1);
+      return parseAsHexa(input, withoutPrefix);
+    }
+
+    return "&" + input + ";";
+  }
+
+  private static String parseAsDecimal(String input, String withoutPrefix) {
+    try {
+      int parsed = Integer.parseInt(withoutPrefix);
+      return Character.toString((char) parsed);
+    } catch (NumberFormatException e) {
+      // Invalid format - just return the input
+      return input;
+    }
+  }
+
+  private static String parseAsHexa(String input, String withoutPrefix) {
+    try {
+      int parsed = (int) Long.parseLong(withoutPrefix, 16);
+      return Character.toString((char) parsed);
+    } catch (NumberFormatException e) {
+      // Invalid format - just return the input
+      return input;
+    }
+  }
+}

--- a/src/test/java/io/vertx/docgen/BaseProcessorTest.java
+++ b/src/test/java/io/vertx/docgen/BaseProcessorTest.java
@@ -197,6 +197,20 @@ public class BaseProcessorTest {
     assertEquals("The $lang is : java", assertDoc("io.vertx.test.lang"));
   }
 
+
+  @Test
+  public void testEntities() throws Exception {
+    final String doc = assertDoc("io.vertx.test.entities");
+    assertTrue("Contains 'Foo & Bar'", doc.contains("Foo &amp; Bar"));
+    assertTrue("Contains '10 $'", doc.contains("10 $"));
+    assertTrue("Contains '10 €", doc.contains("10 €"));
+    assertTrue("Contains 'ß'", doc.contains("<p>Straße</p>"));
+    assertTrue("Contains 'ß'", doc.contains("<p>Straßen</p>"));
+    assertTrue("Contains '\\u00DF'", doc.contains("<p>\\u00DF</p>"));
+    assertTrue("Contains correct json", doc.contains("json.put(\"key\", " +
+        "\"\\u0000\\u0001\\u0080\\u009f\\u00a0\\u00ff\");\n"));
+  }
+
   @Test
   public void testResolveLinkWithClass() throws Exception {
     Compiler<TestGenProcessor> compiler = buildCompiler(new TestGenProcessor(), "io.vertx.test.linkresolution.resolvable");

--- a/src/test/java/io/vertx/docgen/EntityUtilsTest.java
+++ b/src/test/java/io/vertx/docgen/EntityUtilsTest.java
@@ -1,0 +1,28 @@
+package io.vertx.docgen;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Checks the behavior of the entity un-escaper.
+ */
+public class EntityUtilsTest {
+
+  @Test
+  public void testUnescapeEntity() throws Exception {
+    Assert.assertEquals(EntityUtils.unescapeEntity("#92"), "\\");
+    Assert.assertEquals(EntityUtils.unescapeEntity("u00A7"), "§");
+    Assert.assertEquals(EntityUtils.unescapeEntity("#x020AC"), "€");
+    Assert.assertEquals(EntityUtils.unescapeEntity("nbsp"), "&nbsp;");
+    Assert.assertEquals(EntityUtils.unescapeEntity(""), "");
+    Assert.assertEquals(EntityUtils.unescapeEntity(null), "");
+    Assert.assertEquals(EntityUtils.unescapeEntity("\t"), "");
+
+    Assert.assertEquals(EntityUtils.unescapeEntity("#t"), "#t");
+    Assert.assertEquals(EntityUtils.unescapeEntity("uzz02"), "uzz02");
+    Assert.assertEquals(EntityUtils.unescapeEntity("#"), "#");
+    Assert.assertEquals(EntityUtils.unescapeEntity("#x"), "#x");
+  }
+}

--- a/src/test/java/io/vertx/test/entities/package-info.java
+++ b/src/test/java/io/vertx/test/entities/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * This documentation is intended to use <em>entities</em>:
+ * <p/>
+ * <p>Foo &amp; Bar.</p>
+ * <p>10 \u0024</p>
+ * <p>10 &#8364;</p>
+ * <p>Stra\u00DFe</p>
+ * <p>Straßen</p>
+ * <p>&#92;u00DF</p>
+ * <p/>
+ * In code:
+ *
+ * [source,java]
+ * ----
+ * JsonObject json = new JsonObject();
+ * json.put("key", "&#92;u0000&#92;u0001&#92;u0080&#92;u009f&#92;u00a0&#92;u00ff");
+ * json.put("key", "&#92;u00c3&#92;u00bc");
+ * ----
+ */
+@Document package io.vertx.test.entities;
+
+import io.vertx.docgen.Document;


### PR DESCRIPTION
This code adds the support for HTML entities and escaped characters. So it is possible to use:

* `&amp;` => `&amp;` (no change as Asciidoctor supports HTML entities)
* `\u0024` => `$`
* `&#8364;` => `€`
* `&#x020AC;`=> `€`
* `&#92;u00DF` => `\u00DF`

@vietj : can you review.