### PR TITLE
Fix #3 - Add code and literal support

### DIFF
--- a/src/main/java/io/vertx/docgen/BaseProcessor.java
+++ b/src/main/java/io/vertx/docgen/BaseProcessor.java
@@ -284,6 +284,15 @@ public abstract class BaseProcessor extends AbstractProcessor {
         return super.visitText(node, v);
       }
 
+      /**
+       * Handles both literal and code. We generate the asciidoc output using {@literal `}.
+       */
+      @Override
+      public Void visitLiteral(LiteralTree node, Void aVoid) {
+        writer.append("`").append(node.getBody().getBody()).append("`");
+        return super.visitLiteral(node, aVoid);
+      }
+
       @Override
       public Void visitStartElement(StartElementTree node, Void v) {
         copyContent(node);

--- a/src/test/java/io/vertx/docgen/BaseProcessorTest.java
+++ b/src/test/java/io/vertx/docgen/BaseProcessorTest.java
@@ -193,6 +193,11 @@ public class BaseProcessorTest {
   }
 
   @Test
+  public void testCode() throws Exception {
+    assertEquals("This comment contains `some code here` and a `literal`.", assertDoc("io.vertx.test.code"));
+  }
+
+  @Test
   public void testLang() throws Exception {
     assertEquals("The $lang is : java", assertDoc("io.vertx.test.lang"));
   }

--- a/src/test/java/io/vertx/test/code/package-info.java
+++ b/src/test/java/io/vertx/test/code/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This comment contains {@code some code here} and a {@literal literal}.
+ */
+@Document
+package io.vertx.test.code;
+
+import io.vertx.docgen.Document;

--- a/test-proj/src/main/java/test/proj/foofeature/package-info.java
+++ b/test-proj/src/main/java/test/proj/foofeature/package-info.java
@@ -21,6 +21,10 @@
  * === A sub section
  *
  * {@link test.proj.foofeature.subsection}
+ *
+ * === Let's see some code
+ *
+ * There is some code here: {@code System.out.println("Hello");}.
  */
 @Document
 package test.proj.foofeature;


### PR DESCRIPTION
Actually {@code} and {@literal} are handled the same way in the Javadoc AST. The tag values are wrapped between ```.