### PR TITLE
#6 disable translation in source

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ The `{@link }` Javadoc tag includes the referenced elements when this element is
 annotation (otherwise it will just create a link). The `@Source` annotation can annotate a single method, a class
 or a package.
 
+By default the source code is translated to the output language. This feature can be disabled with `@Source
+(translate=false)`. When including source code, the _closest_ (class, package, parent package...) `@Source` annotation
+ is looked up and the value of the `translate` attribute is used. 
+
 ### Lang token
 
 The `$lang` token is replaced by the processed language in:
 - `docgen.output`
-- processed text (@Source is exluded)
+- processed text (@Source is excluded)
 
-The `\$lang` espaces to `$lang`.
+The `\$lang` escapes to `$lang`.
 
 ### Referencing program elements
 

--- a/src/main/java/io/vertx/docgen/Helper.java
+++ b/src/main/java/io/vertx/docgen/Helper.java
@@ -143,6 +143,25 @@ class Helper {
   }
 
   /**
+   * Check the element is an example or not.
+   *
+   * @param elt the elt to check
+   * @return true when the checked element is an example
+   */
+  boolean hasToBeTranslated(Element elt) {
+    // Find the closest source annotation
+    // We are sure to have at least one as this method **must** be called after isExample.
+    Element current = elt;
+    Source source = current.getAnnotation(Source.class);
+    while (source == null) {
+      current = current.getEnclosingElement();
+      source = current.getAnnotation(Source.class);
+    }
+
+    return source.translate();
+  }
+
+  /**
    * Read the source code of the provided element, this returns the source of the entire related compilation unit.
    *
    * @param elt the element to load

--- a/src/main/java/io/vertx/docgen/JavaDocGenProcessor.java
+++ b/src/main/java/io/vertx/docgen/JavaDocGenProcessor.java
@@ -78,48 +78,7 @@ public class JavaDocGenProcessor extends BaseProcessor {
   }
 
   protected String renderSource(ExecutableElement elt, String source) {
-    TreePath resolvedTP = docTrees.getPath(elt);
-    CompilationUnitTree unit = resolvedTP.getCompilationUnit();
-    MethodTree methodTree = (MethodTree) resolvedTP.getLeaf();
-    BlockTree blockTree = methodTree.getBody();
-    // Get block
-    List<? extends StatementTree> statements = blockTree.getStatements();
-    if (statements.size() > 0) {
-      int from = (int) docTrees.getSourcePositions().getStartPosition(unit, statements.get(0));
-      int to = (int) docTrees.getSourcePositions().getEndPosition(unit, statements.get(statements.size() - 1));
-      // Correct boundaries
-      while (from > 1 && source.charAt(from - 1) != '\n') {
-        from--;
-      }
-      while (to < source.length() && source.charAt(to) != '\n') {
-        to++;
-      }
-      String block = source.substring(from, to);
-      // Determine margin
-      int blockMargin = Integer.MAX_VALUE;
-      LineMap lineMap = unit.getLineMap();
-      for (StatementTree statement : statements) {
-        int statementStart = (int) docTrees.getSourcePositions().getStartPosition(unit, statement);
-        int lineStart = statementStart;
-        while (lineMap.getLineNumber(statementStart) == lineMap.getLineNumber(lineStart - 1)) {
-          lineStart--;
-        }
-        blockMargin = Math.min(blockMargin, statementStart - lineStart);
-      }
-      // Crop the fragment
-      StringBuilder fragment = new StringBuilder();
-      for (Iterator<String> sc = new Scanner(block).useDelimiter("\n");sc.hasNext();) {
-        String line = sc.next();
-        int margin = Math.min(blockMargin, line.length());
-        line = line.substring(margin);
-        fragment.append(line);
-        if (sc.hasNext()) {
-          fragment.append('\n');
-        }
-      }
-      return fragment.toString();
-    } else {
-      return null;
-    }
+    // Just use the default rendering process.
+    return defaultRenderSource(elt, source);
   }
 }

--- a/src/main/java/io/vertx/docgen/Source.java
+++ b/src/main/java/io/vertx/docgen/Source.java
@@ -15,4 +15,9 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE,ElementType.PACKAGE,ElementType.METHOD})
 @Retention(RetentionPolicy.CLASS)
 public @interface Source {
+
+  /**
+   * Enables or disables the translation of the annotated example.
+   */
+  boolean translate() default true;
 }

--- a/src/test/java/io/vertx/docgen/BaseProcessorTest.java
+++ b/src/test/java/io/vertx/docgen/BaseProcessorTest.java
@@ -1,5 +1,6 @@
 package io.vertx.docgen;
 
+import junit.framework.Assert;
 import org.junit.Test;
 
 import javax.annotation.processing.Processor;
@@ -197,6 +198,96 @@ public class BaseProcessorTest {
     assertEquals("This comment contains `some code here` and a `literal`.", assertDoc("io.vertx.test.code"));
   }
 
+  /**
+   * This test checks whether or not the source are translated depending on the {@link Source#translate()} attribute.
+   * It analyses the generation of a document using the default generator and a custom generator.
+   */
+  @Test
+  public void testSource() throws Exception {
+    String doc = assertDoc("io.vertx.test.source");
+
+    // Just use the Java processor - eveything is in lower case.
+
+    assertTrue("#1", doc.contains("# 1\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#2", doc.contains("# 2\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#3", doc.contains("# 3\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#4", doc.contains("# 4\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#5", doc.contains("# 5\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#6", doc.contains("# 6\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    // Now with the custom generator
+    // Source that need to be translated is in uppercase, otherwise lowercase (regular)
+    // Are not translated:
+    // #2 - because of @Source(translate = false) on the class itself
+    // #4 - like #2 - override parent package configuration
+
+    doc = assertDocWithCustomGenerator("io.vertx.test.source");
+    assertTrue("#1", doc.contains("# 1\n" +
+        "[source, custom]\n" +
+        "----\n" +
+        "SYSTEM.OUT.PRINTLN(\"HELLO\");\n" +
+        "----"));
+
+    assertTrue("#2", doc.contains("# 2\n" +
+        "[source, custom]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#3", doc.contains("# 3\n" +
+        "[source, custom]\n" +
+        "----\n" +
+        "SYSTEM.OUT.PRINTLN(\"HELLO\");\n" +
+        "----"));
+
+    assertTrue("#4", doc.contains("# 4\n" +
+        "[source, custom]\n" +
+        "----\n" +
+        "System.out.println(\"Hello\");\n" +
+        "----"));
+
+    assertTrue("#5", doc.contains("# 5\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "SYSTEM.OUT.PRINTLN(\"HELLO\");\n" +
+        "----"));
+
+    assertTrue("#6", doc.contains("# 6\n" +
+        "[source, java]\n" +
+        "----\n" +
+        "SYSTEM.OUT.PRINTLN(\"HELLO\");\n" +
+        "----"));
+  }
+
   @Test
   public void testLang() throws Exception {
     assertEquals("The $lang is : java", assertDoc("io.vertx.test.lang"));
@@ -299,6 +390,12 @@ public class BaseProcessorTest {
 
   private String assertDoc(String pkg) throws Exception {
     Compiler<TestGenProcessor> compiler = buildCompiler(new TestGenProcessor(), pkg);
+    compiler.assertCompile();
+    return compiler.processor.getDoc(pkg);
+  }
+
+  private String assertDocWithCustomGenerator(String pkg) throws Exception {
+    Compiler<CustomTestGenProcessor> compiler = buildCompiler(new CustomTestGenProcessor(), pkg);
     compiler.assertCompile();
     return compiler.processor.getDoc(pkg);
   }

--- a/src/test/java/io/vertx/docgen/CustomTestGenProcessor.java
+++ b/src/test/java/io/vertx/docgen/CustomTestGenProcessor.java
@@ -1,0 +1,80 @@
+package io.vertx.docgen;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A custom processor.
+ * On purpose it transforms source to uppercase.
+ */
+public class CustomTestGenProcessor extends JavaDocGenProcessor {
+
+  Map<String, String> results = new HashMap<>();
+
+  @Override
+  protected String resolveLinkToPackageDoc(PackageElement elt) {
+    return "package[" + elt.getQualifiedName() + "]";
+  }
+
+  @Override
+  protected String resolveTypeLink(TypeElement elt, Coordinate coordinate) {
+    switch (elt.getKind()) {
+      case INTERFACE:
+      case CLASS:
+        return "type";
+      case ENUM:
+        return "enum";
+      default:
+        return "unsupported";
+    }
+  }
+
+  @Override
+  protected String resolveConstructorLink(ExecutableElement elt, Coordinate coordinate) {
+    return "constructor";
+  }
+
+  @Override
+  protected String resolveMethodLink(ExecutableElement elt, Coordinate coordinate) {
+    return "method";
+  }
+
+  @Override
+  protected String resolveFieldLink(VariableElement elt, Coordinate coordinate) {
+    switch (elt.getKind()) {
+      case ENUM_CONSTANT:
+        return "enumConstant";
+      case FIELD:
+        return "field";
+      default:
+        return "unsupported";
+    }
+  }
+
+  @Override
+  protected void handleGen(PackageElement docElt) {
+    StringWriter buffer = new StringWriter();
+    process(buffer, docElt);
+    String content = buffer.toString();
+    results.put(docElt.getQualifiedName().toString(), content);
+  }
+
+  public String getDoc(String name) {
+    return results.get(name);
+  }
+
+  @Override
+  protected String getName() {
+    return "custom";
+  }
+
+  @Override
+  protected String renderSource(ExecutableElement elt, String source) {
+    return defaultRenderSource(elt, source).toUpperCase();
+  }
+}

--- a/src/test/java/io/vertx/test/source/Example.java
+++ b/src/test/java/io/vertx/test/source/Example.java
@@ -1,0 +1,15 @@
+package io.vertx.test.source;
+
+import io.vertx.docgen.Source;
+
+/**
+ * Dummy class used in tests.
+ */
+@Source
+public class Example {
+
+  public void hello() {
+    System.out.println("Hello");
+  }
+
+}

--- a/src/test/java/io/vertx/test/source/ExampleNotTranslated.java
+++ b/src/test/java/io/vertx/test/source/ExampleNotTranslated.java
@@ -1,0 +1,15 @@
+package io.vertx.test.source;
+
+import io.vertx.docgen.Source;
+
+/**
+ * The code from this class must not be translated.
+ */
+@Source(translate = false)
+public class ExampleNotTranslated {
+
+  public void hello() {
+    System.out.println("Hello");
+  }
+
+}

--- a/src/test/java/io/vertx/test/source/notTranslated/Example.java
+++ b/src/test/java/io/vertx/test/source/notTranslated/Example.java
@@ -1,0 +1,15 @@
+package io.vertx.test.source.notTranslated;
+
+import io.vertx.docgen.Source;
+
+/**
+ * Dummy class used in tests.
+ */
+@Source
+public class Example {
+
+  public void hello() {
+    System.out.println("Hello");
+  }
+
+}

--- a/src/test/java/io/vertx/test/source/notTranslated/package-info.java
+++ b/src/test/java/io/vertx/test/source/notTranslated/package-info.java
@@ -1,0 +1,4 @@
+@Source(translate = false)
+package io.vertx.test.source.notTranslated;
+
+import io.vertx.docgen.Source;

--- a/src/test/java/io/vertx/test/source/notTranslated/sub/Example.java
+++ b/src/test/java/io/vertx/test/source/notTranslated/sub/Example.java
@@ -1,0 +1,12 @@
+package io.vertx.test.source.notTranslated.sub;
+
+import io.vertx.docgen.Source;
+
+@Source(translate = true)
+public class Example {
+
+  public void hello() {
+    System.out.println("Hello");
+  }
+
+}

--- a/src/test/java/io/vertx/test/source/package-info.java
+++ b/src/test/java/io/vertx/test/source/package-info.java
@@ -1,0 +1,36 @@
+/**
+ * # 1
+ * [source, $lang]
+ * ----
+ * {@link io.vertx.test.source.Example#hello()}
+ * ----
+ * # 2
+ * [source, $lang]
+ * ----
+ * {@link io.vertx.test.source.ExampleNotTranslated#hello()}
+ * ----
+ * # 3
+ * [source, $lang]
+ * ----
+ * {@link io.vertx.test.source.translated.Example#hello()}
+ * ----
+ * # 4
+ * [source, $lang]
+ * ----
+ * {@link io.vertx.test.source.translated.sub.Example#hello()}
+ * ----
+ * # 5
+ * [source, java]
+ * ----
+ * {@link io.vertx.test.source.notTranslated.Example#hello()}
+ * ----
+ * # 6
+ * [source, java]
+ * ----
+ * {@link io.vertx.test.source.notTranslated.sub.Example#hello()}
+ * ----
+ */
+@Document
+package io.vertx.test.source;
+
+import io.vertx.docgen.Document;

--- a/src/test/java/io/vertx/test/source/translated/Example.java
+++ b/src/test/java/io/vertx/test/source/translated/Example.java
@@ -1,0 +1,15 @@
+package io.vertx.test.source.translated;
+
+import io.vertx.docgen.Source;
+
+/**
+ * Dummy class used in tests.
+ */
+@Source
+public class Example {
+
+  public void hello() {
+    System.out.println("Hello");
+  }
+
+}

--- a/src/test/java/io/vertx/test/source/translated/package-info.java
+++ b/src/test/java/io/vertx/test/source/translated/package-info.java
@@ -1,0 +1,4 @@
+@Source
+package io.vertx.test.source.translated;
+
+import io.vertx.docgen.Source;

--- a/src/test/java/io/vertx/test/source/translated/sub/Example.java
+++ b/src/test/java/io/vertx/test/source/translated/sub/Example.java
@@ -1,0 +1,13 @@
+package io.vertx.test.source.translated.sub;
+
+import io.vertx.docgen.Source;
+
+@Source(translate = false)
+public class Example {
+
+  public void hello() {
+    System.out.println("Hello");
+  }
+
+
+}


### PR DESCRIPTION
Adds a `translate` attribute to `@Source` to enable / disable the code translation. Translation is enabled by default.

When including source code, the _closest_ `@Source` annotation is looked up in this order: `class`, `package`, `parent package`... The first `@Source` found is used to determine whether or not the translation needs to be enabled or not.

When disabled, Java source is included.